### PR TITLE
Added support for a person mode 

### DIFF
--- a/anno1602.py
+++ b/anno1602.py
@@ -69,8 +69,8 @@ if len(sys.argv) < 2:
     print("Usage: {} relative/path/to_file.bag".format(sys.argv[0]))
     print()
     print("relative to {}".format(basedir))
-    print("Too perform a dry run withint savinr results use --dry-run or -n.")
-    print("Too change into walking person annotation mode use --person or -p.")
+    print("To perform a dry run without saving results use --dry-run or -n.")
+    print("To change into person annotation mode use --person or -p.")
     sys.exit(1)
 
 # Very crude, not robust argv handling.
@@ -87,7 +87,7 @@ for arg in sys.argv[1:]:
         if name is None:
             name = arg
         else:
-            print("Cannot parse arguments, please only specify a single path to the data, and/or flags for dry-run or person only annotations.")
+            print("Cannot parse arguments, please only specify a single path to the data, and/or flags for dry run or person only annotations.")
             sys.exit(1)
 
 


### PR DESCRIPTION
and thus also changed how arguments are handled.

Now simply add --person or -p to save person annotations into a *.wp file.

I tested saving, loading deleting afterwards in combination with dry run and without. Wheelchair and walker labels are not affected. Don't trust me on this and also give it a test run, but it should be pretty much working.

I was a bit confused by how saving works (switching batches) it would be a shame if we lose data because we forget to do this in the last batch, maybe we should change the default saving behaviour?